### PR TITLE
fixed Wire.begin(sda, scl) issue.  Wire.begin() must always be called…

### DIFF
--- a/MLX90393.cpp
+++ b/MLX90393.cpp
@@ -60,8 +60,6 @@ begin(uint8_t A1, uint8_t A0, int DRDY_pin, TwoWire &wirePort)
 
   _i2cPort = &wirePort; //Grab which port the user wants us to use
 
-  _i2cPort->begin();
-
   uint8_t status1 = checkStatus(reset());
   uint8_t status2 = setGainSel(7);
   uint8_t status3 = setResolution(0, 0, 0);

--- a/examples/read_MLX90393/read_MLX90393.ino
+++ b/examples/read_MLX90393/read_MLX90393.ino
@@ -7,8 +7,13 @@
 MLX90393 mlx;
 
 void setup(){
+  Wire.begin();
+  //Wire.begin(18 /*SDA*/, 19 /*SCL*/);
+    
   // DRDY line connected to A3 (omit third parameter to used timed reads)
   //uint8_t status = mlx.begin(0, 0, A3);
+
+  // using timed reads
   uint8_t status = mlx.begin(0, 0);
   Serial.begin(9600);
 }


### PR DESCRIPTION
… now.