### PR TITLE
Rename argument names to avoid clash with xmc1100 arduino framework

### DIFF
--- a/MLX90393.cpp
+++ b/MLX90393.cpp
@@ -36,9 +36,9 @@ MLX90393()
 
 uint8_t
 MLX90393::
-begin(uint8_t A1, uint8_t A0, int DRDY_pin, TwoWire &wirePort)
+begin(uint8_t addr1, uint8_t addr0, int DRDY_pin, TwoWire &wirePort)
 {
-  I2C_address = I2C_BASE_ADDR | (A1?2:0) | (A0?1:0);
+  I2C_address = I2C_BASE_ADDR | (addr1?2:0) | (addr0?1:0);
   this->DRDY_pin = DRDY_pin;
   if (DRDY_pin >= 0){
     pinMode(DRDY_pin, INPUT);

--- a/MLX90393.cpp
+++ b/MLX90393.cpp
@@ -561,8 +561,8 @@ setResolution(uint8_t res_x, uint8_t res_y, uint8_t res_z)
   uint16_t old_val;
   uint8_t status1 = readRegister(RES_XYZ_REG, old_val);
   uint8_t status2 = writeRegister(RES_XYZ_REG,
-                                  (old_val & ~RES_XYZ_MASK) |
-                                  (res_xyz << RES_XYZ_SHIFT) & RES_XYZ_MASK);
+                                 ((old_val & ~RES_XYZ_MASK) |
+                                  (res_xyz << RES_XYZ_SHIFT)) & RES_XYZ_MASK);
   return checkStatus(status1) | checkStatus(status2);
 }
 

--- a/MLX90393.h
+++ b/MLX90393.h
@@ -84,7 +84,7 @@ public:
   uint16_t convDelayMillis();
 
   // higher-level API
-  uint8_t begin(uint8_t A1 = 0, uint8_t A0 = 0, int DRDY_pin = -1, TwoWire &wirePort = Wire);
+  uint8_t begin(uint8_t addr1 = 0, uint8_t addr0 = 0, int DRDY_pin = -1, TwoWire &wirePort = Wire);
 
   // returns B (x,y,z) in uT, temperature in C
   uint8_t readData(txyz& data);

--- a/MLX90393.h
+++ b/MLX90393.h
@@ -119,7 +119,7 @@ private:
 
   // parameters are cached to avoid reading them from sensor unnecessarily
   struct cache_t {
-    enum { SIZE = 3, ALL_DIRTY_MASK = 1 << (SIZE + 1) - 1};
+    enum { SIZE = 3, ALL_DIRTY_MASK = (1 << (SIZE + 1)) - 1};
     uint8_t dirty;
     uint16_t reg[SIZE];
   } cache;


### PR DESCRIPTION
Hi, this library fails to compile out of the box because the Infineon XMC1100 series Arduino framework appears to `#define` `A1` and `A0` - this seems a bit silly, but simply changing the argument name in the begin function makes it work